### PR TITLE
[NGC-3723][FD] Remove api platform confidence level check

### DIFF
--- a/app/uk/gov/hmrc/mobileusercontact/views/definition.scala.txt
+++ b/app/uk/gov/hmrc/mobileusercontact/views/definition.scala.txt
@@ -7,8 +7,7 @@
     {
       "key": "read:native-apps-api-orchestration",
       "name": "Native Apps API Orchestration",
-      "description": "Access APIs that are provided specifically for use by the HMRC mobile apps",
-      "confidenceLevel": 200
+      "description": "Access APIs that are provided specifically for use by the HMRC mobile apps"
     }
   ],
   "api": {


### PR DESCRIPTION
We believe it is triggering IV for the production sandbox user, which is undesirable because we don't want to associate the production sandbox user with a real NINO.
It also triggers IV earlier than the mobile app expects it which causes problems for real users too.